### PR TITLE
Correct the default location for Asciidoctor sources in Gradle.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -320,7 +320,7 @@ asciidoctor {
 ----
 ====
 
-NOTE: The default location for Asciidoctor sources in Gradle is `src/doc/asciidoc`. We set
+NOTE: The default location for Asciidoctor sources in Gradle is `src/docs/asciidoc`. We set
 the `sourceDir` to match the default for Maven.
 
 == Summary


### PR DESCRIPTION
In the [Spring REST Docs document](https://docs.spring.io/spring-restdocs/docs/current/reference/html5/#getting-started-using-the-snippets), the default location for Asciidoctor sources in Gradle is `src/docs/asciidoc`. not `src/doc/asciidoc`